### PR TITLE
fix(backend): fix mailer adapter import for NestJS 11 compatibility

### DIFF
--- a/backend/src/shared/mailer.module.ts
+++ b/backend/src/shared/mailer.module.ts
@@ -1,7 +1,7 @@
 import { Module } from '@nestjs/common'
 import { ConfigModule, ConfigService } from '@nestjs/config'
 import { MailerModule as NestMailerModule } from '@nestjs-modules/mailer'
-import { HandlebarsAdapter } from '@nestjs-modules/mailer/dist/adapters/handlebars.adapter'
+import { HandlebarsAdapter } from '@nestjs-modules/mailer/adapters/handlebars.adapter'
 import { join } from 'path'
 import { MailService } from './mail.service'
 


### PR DESCRIPTION
## Problem
Production crash on startup:
```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './dist/adapters/handlebars.adapter' 
is not defined by "exports" in @nestjs-modules/mailer/package.json
```

## Fix
Changed import path from `@nestjs-modules/mailer/dist/adapters/handlebars.adapter` to `@nestjs-modules/mailer/adapters/handlebars.adapter` to match the package's exports map.

## Test plan
- [x] `npm run build` succeeds
- [x] `npm test` passes (25/25)

🤖 Generated with [Claude Code](https://claude.com/claude-code)